### PR TITLE
test(windows): tolerate relaunch file-lock cleanup

### DIFF
--- a/windows/tests/AkangVoiceInput.Tests/WindowsUpdateServiceTests.cs
+++ b/windows/tests/AkangVoiceInput.Tests/WindowsUpdateServiceTests.cs
@@ -142,7 +142,30 @@ public sealed class WindowsUpdateServiceTests
         }
         finally
         {
-            Directory.Delete(root, recursive: true);
+            await DeleteDirectoryEventuallyAsync(root);
+        }
+    }
+
+    private static async Task DeleteDirectoryEventuallyAsync(string path)
+    {
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+                return;
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException &&
+                attempt < 49)
+            {
+                // The updater relaunches the dummy executable. Windows can keep
+                // that file locked briefly after the short-lived process exits.
+                await Task.Delay(100);
+            }
         }
     }
 


### PR DESCRIPTION
The updater integration test relaunches a short-lived dummy executable. GitHub-hosted Windows runners can retain its image lock briefly after the replacement assertion succeeds. Retry temporary-directory cleanup for up to five seconds. The full 33-test suite passed three consecutive local Release runs.